### PR TITLE
Add CHANGELOG.md check

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,34 @@
+name: Check CHANGELOG.md
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    name: CHANGELOG.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint CHANGELOG.md
+        run: |
+            # Install jbang
+            curl -Ls https://sh.jbang.dev | bash -s - app setup
+            export PATH=$PATH:$HOME/.jbang/bin
+
+            jbang com.github.nbbrd.heylogs:heylogs-cli:0.9.3:bin check CHANGELOG.md > heylogs.txt || true
+
+            cat heylogs.txt
+
+            sed -n '/^CHANGELOG\.md$/,$ { /^CHANGELOG\.md$/d; p }' heylogs.txt >> $GITHUB_STEP_SUMMARY
+
+            grep -q "No problem" heylogs.txt || exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# Changelog Merge Driver Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - [SNAPSHOT]
+## [Unreleased]
 
 
 
@@ -36,3 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2024-04-29
 
 First released version.
+
+[Unreleased]: https://github.com/maven-flow/changelog-merge-driver/compare/0.4.0...HEAD
+[0.4.0]: https://github.com/maven-flow/changelog-merge-driver/compare/0.3.0...0.4.0
+[0.3.0]: https://github.com/maven-flow/changelog-merge-driver/compare/0.2.0...0.3.0
+[0.2.0]: https://github.com/maven-flow/changelog-merge-driver/compare/0.1.0...0.2.0
+[0.1.0]: https://github.com/maven-flow/changelog-merge-driver/releases/tag/0.1.0


### PR DESCRIPTION
I am using [heylogs](https://github.com/nbbrd/heylogs) to check the CHANGELOG.md file.

The first check returns:

```lua
   1:1  error  Invalid text               for-humans              
   8:1  error  Invalid date format        all-h2-contain-a-version
  12:1  error  Missing reference '0.4.0'  linkable                
  18:1  error  Missing reference '0.3.0'  linkable                
  24:1  error  Missing reference '0.2.0'  linkable                
  36:1  error  Missing reference '0.1.0'  linkable       
```

I fixed all of it.

Follow-up:

- Have tags for each release: https://github.com/maven-flow/changelog-merge-driver/tags
- (Optional) Patch [github-release-from-changelog](https://github.com/MoOx/github-release-from-changelog) to work without `package.json` for getting the latest version.